### PR TITLE
Allow 'null' parameter values.

### DIFF
--- a/lib/Request.js
+++ b/lib/Request.js
@@ -6,32 +6,33 @@ import lazy from 'lazy.js';
 import assert from 'fluent-assert';
 import getType from './types';
 
-let logger  = Logger('Request');
+let logger = Logger('Request');
 
 let TediousRequest = tedious.Request;
 
 export default class Request extends TediousRequest {
-  constructor(sql){
+  constructor(sql) {
     super(sql, (err, rowCount) => {
-      if(err){
-        throw(err);
+      if (err) {
+        throw (err);
       }
       logger.debug('RowCount: %o', rowCount);
     });
-    if(!sql){
+    if (!sql) {
       throw new Error('Must provide something that can be executed via sql');
     }
   }
 
-/**
- * Adds parameters to the request
- * @param {object} params The object to create
- */
-  addParameters(params){
+  /**
+   * Adds parameters to the request
+   * @param {object} params The object to create
+   */
+  addParameters(params) {
     lazy(params)
       .each((metadata, key) => {
-        assert.ok('value', metadata.value);
         assert.ok('type', metadata.type);
+        //Allow anything but undefined, including null...
+        assert.ok('value', metadata.value === undefined ? undefined : 1);
         let type = getType(metadata.type);
         logger.debug('Adding parameter for %s', key);
         super.addParameter(key, type, metadata.value);
@@ -43,7 +44,7 @@ export default class Request extends TediousRequest {
    * @param {object} params - an object of objects
    *   - { name: NVARCHAR }
    */
-  addOutputParameters(params){
+  addOutputParameters(params) {
     lazy(params)
       .each((type, param) => {
         logger.debug('Adding outputParam for %s', param);

--- a/spec/request-test.js
+++ b/spec/request-test.js
@@ -31,6 +31,12 @@ describe('request', () => {
       }).to.throw(/undefined/);
     });
 
+    it('allows value of null', () => {
+      expect(() => {
+        request.addParameters({ 'blah': { type: 'aha!', value: null } });
+      }).to.not.throw(/undefined/);
+    });
+
     it('throws an exception if type is not provided', () => {
       expect(() => {
         request.addParameters({ 'blah': { value: 'aha!' } });


### PR DESCRIPTION
- Modified assert to spoof positive for anything other than undefined
- Add test to check allow for null
