### PR TITLE
when adding a parameter, pass the metadata as the options

### DIFF
--- a/lib/Request.js
+++ b/lib/Request.js
@@ -33,7 +33,7 @@ export default class Request extends TediousRequest {
         assert.defined('value', metadata.value);
         let type = getType(metadata.type);
         logger.debug('Adding parameter for %s', key);
-        super.addParameter(key, type, metadata.value);
+        super.addParameter(key, type, metadata.value, metadata);
       });
   }
 


### PR DESCRIPTION
when adding a parameter, pass the metadata as the options, so that consumers can specify things like length, precision, scale...

For example, decimal types.  With out these, 1.25 becomes 1.00 on the wire.
